### PR TITLE
Use element event instead function callback on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ $('h1').vanish();
 
 $('p').vanish({
   duration: 2500,
-  animation: 200,
-  onAllVanished: function() {
-    alert('Vanish ends');
-  }
+  animation: 200
 });
 ```
 
@@ -42,7 +39,23 @@ $('p').vanish({
 | duration      | Number   | 3000           | The duration in milliseconds to vanish all string |
 | animation     | Number   | 300            | The time of an item vanish animation |
 | className     | String   | 'is-vanishing' | A class to add when the character starts to vanish |
-| onAllVanished | Function | null           | Optional callback to call when all itens vanished |
+
+### Events
+
+The element should trigger a `vanished` event. You'll use like:
+
+```html
+<p>Other Foo Bar</p>
+```
+
+```javascript
+$('p').vanish({
+  duration: 2500,
+  animation: 200,
+}).on('vanished', function() {
+  alert('Vanish ends');
+})
+```
 
 ## License
 

--- a/jquery.vanish.js
+++ b/jquery.vanish.js
@@ -11,18 +11,13 @@
  *    default to 300ms
  *  {String} className, a class to add when the
  *    character starts to vanish, default to 'is-vanishing'
- *  {Function} onAllVanished, optional callback
- *    to call when all itens vanished
  *
  * @example
  *  <h1 class="foo">Hello Foo Bar</h1>
  *
  *  $('.foo').vanish({
  *    duration: 2500,
- *    animation: 200,
- *    onAllVanished: function() {
- *      alert('Vanish ends');
- *    }
+ *    animation: 200
  *  });
  */
 
@@ -32,8 +27,7 @@
   var defaults = {
     duration: 3000,
     animation: 300,
-    className: 'is-vanishing',
-    onAllVanished: null
+    className: 'is-vanishing'
   };
 
   function Vanish(element, options) {
@@ -94,9 +88,7 @@
   Vanish.prototype.endVanishment = function(index) {
     clearInterval(this.settings.timer);
 
-    if (typeof this.settings.onAllVanished === 'function') {
-      this.settings.onAllVanished();
-    }
+    this.element.trigger('vanished');
   };
 
   Vanish.prototype.vanish = function() {

--- a/spec/jquery.vanish.spec.js
+++ b/spec/jquery.vanish.spec.js
@@ -15,8 +15,8 @@ describe('Jquery Vanish', function() {
       subject.vanish({
         duration: 100,
         animation: 0,
-        onAllVanished: foo.fn
       });
+      subject.on('vanished', foo.fn)
 
       jasmine.clock().tick(99);
       expect(foo.fn).not.toHaveBeenCalled();

--- a/spec/jquery.vanish.spec.js
+++ b/spec/jquery.vanish.spec.js
@@ -16,7 +16,7 @@ describe('Jquery Vanish', function() {
         duration: 100,
         animation: 0,
       });
-      subject.on('vanished', foo.fn)
+      subject.on('vanished', foo.fn);
 
       jasmine.clock().tick(99);
       expect(foo.fn).not.toHaveBeenCalled();


### PR DESCRIPTION
Sample code: 

```
$('p').vanish({
  duration: 100,
  animation: 0,
}).on('vanished', foo.fn);
```
